### PR TITLE
Fix to make Avahi work in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,25 @@
 [![Build Status](https://secure.travis-ci.org/pwelch/chef-avahi.svg)](http://travis-ci.org/pwelch/chef-avahi)
 
 ## Description
+
 Chef cookbook that installs and configures [avahi](http://avahi.org/) the zeroconf software.
 
 ## Usage
+
 Include `avahi::default` recipe in the `run_list`.
 
 To disable the avahi-daemon set the attribute like so:
+
 ```
-  node.default['avahi']['disable_service'] = true
+node.default['avahi']['disable_service'] = true
+```
+
+### Avahi in Docker
+
+By default Avahi can only run in a single container as described [here](https://github.com/lxc/lxd/issues/2948#issuecomment-282386962). To get around this limitation you can disable the `rlimit` related config by adding:
+
+```
+node.default['avahi']['rlimit']['conf'] = false
 ```
 
 ## Development
@@ -20,6 +31,7 @@ Development requires [ChefDK](https://downloads.chef.io/chefdk)
 ## Testing
 
 Running tests:
+
 ```bash
 chef exec rake
 chef exec kitchen verify

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,3 +19,13 @@ default['avahi']['hostname'] = node['hostname']
 default['avahi']['domain']   = 'local'
 default['avahi']['useipv4']  = 'yes'
 default['avahi']['useipv6']  = 'no'
+
+# rlimits config
+
+default['avahi']['rlimit']['conf'] = true
+default['avahi']['rlimit']['core'] = 0
+default['avahi']['rlimit']['data'] = 4194304
+default['avahi']['rlimit']['fsize'] = 0
+default['avahi']['rlimit']['nofile'] = 300
+default['avahi']['rlimit']['nproc'] = 3
+default['avahi']['rlimit']['stack'] = 4194304

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,18 @@ package node['avahi']['package_name'] do
   action :install
 end
 
+template '/etc/avahi/avahi-daemon.conf' do
+  source 'avahi-daemon.conf.erb'
+  owner 'root'
+  group 'root'
+  variables(hostname: node['avahi']['hostname'],
+            domain:   node['avahi']['domain'],
+            useipv4:  node['avahi']['useipv4'],
+            useipv6:  node['avahi']['useipv6'],
+            rlimit:   node['avahi']['rlimit'])
+  notifies :restart, 'service[avahi-daemon]'
+end
+
 if node['avahi']['disable_service']
   service 'avahi-daemon' do
     action [:disable, :stop]
@@ -15,15 +27,4 @@ else
   service 'avahi-daemon' do
     action [:enable, :start]
   end
-end
-
-template '/etc/avahi/avahi-daemon.conf' do
-  source 'avahi-daemon.conf.erb'
-  owner 'root'
-  group 'root'
-  variables(hostname: node['avahi']['hostname'],
-            domain:   node['avahi']['domain'],
-            useipv4:  node['avahi']['useipv4'],
-            useipv6:  node['avahi']['useipv6'])
-  notifies :restart, 'service[avahi-daemon]'
 end

--- a/templates/default/avahi-daemon.conf.erb
+++ b/templates/default/avahi-daemon.conf.erb
@@ -55,11 +55,13 @@ enable-wide-area=yes
 #enable-reflector=no
 #reflect-ipv=no
 
+<%- if @rlimit['conf'] -%>
 [rlimits]
 #rlimit-as=
-rlimit-core=0
-rlimit-data=4194304
-rlimit-fsize=0
-rlimit-nofile=300
-rlimit-stack=4194304
-rlimit-nproc=3
+rlimit-core=<%= @rlimit['core'] %>
+rlimit-data=<%= @rlimit['data'] %>
+rlimit-fsize=<%= @rlimit['fsize'] %>
+rlimit-nofile=<%= @rlimit['nofile'] %>
+rlimit-stack=<%= @rlimit['stack'] %>
+rlimit-nproc=<%= @rlimit['nproc'] %>
+<%- end -%>


### PR DESCRIPTION
Hi there!

I just started using this cookbook to configure mDNS for testing Chef cookbooks with multiple hosts and while this works fine when using VMs, it does not cope with docker due to a limitation which I found [here](https://github.com/lxc/lxd/issues/2948#issuecomment-282386962) and the fix [here](https://forum.openmediavault.org/index.php/Thread/17636-solved-avahi-daemon-and-lxc/).

Instead of removing just the `rlimit-nproc` config I was able to get it working by removing all rlimit related config - so I've made this configurable via attribute.

This also required a minor reshuffle of the default recipe to load start the service after the template had been rendered.

Stephen